### PR TITLE
v1.4.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "service": "homeassistant",
   "workspaceFolder": "/workspaces/ha-wifi-ssid-monitor",
   "_comment": "Added -U to ensure it upgrades if a cached version is old",
-  "postCreateCommand": "mkdir -p .reports/devcontainer && sh .devcontainer/setup.sh || (echo 'Setup failed! Check .reports/devcontainer/post_setup.log for details.' && sleep infinity)",
+  "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && sh .devcontainer/setup.sh || (echo 'Setup failed! Check .reports/devcontainer/post_setup.log for details.' && sleep infinity)",
   "mounts": [
     {
       "source": "${localEnv:USERPROFILE}/.gemini",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,11 @@
       "source": "${localEnv:USERPROFILE}/.gemini",
       "target": "/root/.gemini",
       "type": "bind"
+    },
+    {
+      "source": "${localEnv:USERPROFILE}/.gitconfig",
+      "target": "/root/.gitconfig",
+      "type": "bind"
     }
   ],
   "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   homeassistant:
     container_name: wifi-ssid-monitor-dev
-    image: ghcr.io/home-assistant/home-assistant:stable
+    image: ha-dev-base:latest
     volumes:
       # Mount the whole project so the DevContainer workspace works
       - ..:/workspaces/ha-wifi-ssid-monitor

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,39 +1,19 @@
 #!/bin/sh
 
-# Ensure the directory exists
-mkdir -p .reports/devcontainer ;
+# Setup log directory
+mkdir -p .reports/devcontainer
+LOG_FILE=".reports/devcontainer/post_setup.log"
 
-# 1. Git Configuration (Moved to start to ensure completion)
-echo "--- Starting Post-Create Setup ---" | tee .reports/devcontainer/post_setup.log ;
-echo "Configuring Git..." | tee -a .reports/devcontainer/post_setup.log ;
-git config --global core.fileMode false 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-git config --global core.autocrlf input 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
+# Use a subshell to capture all output to the log file
+(
+    echo "--- Starting Post-Create Setup ---"
+    
+    echo "Configuring Git..."
+    git config --global core.fileMode false
+    git config --global core.autocrlf input
 
-# 2. System Packages
-echo "Installing system packages (apk)..." | tee -a .reports/devcontainer/post_setup.log ;
-apk update 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-apk add nodejs npm bash libc6-compat ncurses coreutils 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
+    echo "Environment: ha-dev-base:latest"
+    echo "Gemini CLI: $(which gemini || echo 'Not found in path')"
 
-# 3. Python Dependencies
-echo "Installing Python test dependencies..." | tee -a .reports/devcontainer/post_setup.log ;
-pip install -r .validate/requirements_test.txt 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-
-# 4. Global NPM Tools
-echo "Installing global NPM tools..." | tee -a .reports/devcontainer/post_setup.log ;
-npm install -g @google/gemini-cli markdown-link-check markdownlint-cli prettier 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-
-# 5. Gemini CLI Configuration
-echo "Configuring Gemini CLI..." | tee -a .reports/devcontainer/post_setup.log ;
-# Clean up path by stripping any carriage returns
-NODE_ROOT=$(npm root -g | tr -d '\r') ;
-REAL_GEMINI_PATH="$NODE_ROOT/@google/gemini-cli/bundle/gemini.js" ;
-
-# Use series of && to avoid if/then/else/fi syntax errors with Windows line endings
-[ -f "$REAL_GEMINI_PATH" ] && echo "Found Gemini at: $REAL_GEMINI_PATH" | tee -a .reports/devcontainer/post_setup.log ;
-[ -f "$REAL_GEMINI_PATH" ] && sed -i '1s|.*|#!/usr/bin/node|' "$REAL_GEMINI_PATH" 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-[ -f "$REAL_GEMINI_PATH" ] && ln -sf "$REAL_GEMINI_PATH" /usr/local/bin/gemini 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-[ -f "$REAL_GEMINI_PATH" ] && chmod +x /usr/local/bin/gemini 2>&1 | tee -a .reports/devcontainer/post_setup.log ;
-[ -f "$REAL_GEMINI_PATH" ] && echo "Gemini CLI configured successfully." | tee -a .reports/devcontainer/post_setup.log ;
-[ -f "$REAL_GEMINI_PATH" ] || echo "Warning: gemini.js not found at $REAL_GEMINI_PATH. Manual check required." | tee -a .reports/devcontainer/post_setup.log ;
-
-echo "--- Setup Complete ---" | tee -a .reports/devcontainer/post_setup.log ;
+    echo "--- Setup Complete ---"
+) 2>&1 | tee "$LOG_FILE"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Don't include the 'tests' folder in the final .zip download
+/tests export-ignore

--- a/.validate/.codespellrc
+++ b/.validate/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./.venv,./.ruff_cache,./.pytest_cache
+ignore-words-list = hass

--- a/.validate/requirements_test.txt
+++ b/.validate/requirements_test.txt
@@ -3,3 +3,4 @@ pytest-homeassistant-custom-component
 pytest-cov
 yamllint
 check-jsonschema
+codespell

--- a/.validate/requirements_test.txt
+++ b/.validate/requirements_test.txt
@@ -1,5 +1,5 @@
 ruff
-pytest-homeassistant-custom-component
+pytest-homeassistant-custom-component==0.13.326
 pytest-cov
 yamllint
 check-jsonschema

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -125,6 +125,26 @@
       "problemMatcher": []
     },
     {
+      "label": "Codespell: Check (View Only)",
+      "type": "shell",
+      "command": "mkdir -p .reports && codespell . --config .validate/.codespellrc | tee .reports/codespell.txt",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Codespell: Fix (Auto-Repair)",
+      "type": "shell",
+      "command": "codespell . --config .validate/.codespellrc -w || true",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Prettier: Check (View Only)",
       "type": "shell",
       "command": "mkdir -p .reports && git ls-files -z --cached --others --exclude-standard '*.md' '*.json' '*.yaml' '*.yml' | xargs -0 -r prettier --config .validate/.prettierrc --check | tee .reports/prettier_check.txt",
@@ -214,6 +234,7 @@
         "Ruff: Format Check (View Only)",
         "Markdown: Check Links",
         "Markdown: Lint (View Only)",
+        "Codespell: Check (View Only)",
         "Prettier: Check (View Only)",
         "Pytest: Run All Tests",
         "Pytest: Check Test Coverage"
@@ -235,6 +256,7 @@
         "Ruff: Check Fix (Auto-Repair Lint)",
         "Ruff: Format Fix (Auto-Repair)",
         "Markdown: Lint (Auto-Fix)",
+        "Codespell: Fix (Auto-Repair)",
         "Prettier: Format (Auto-Fix)",
         "Prettier: Fix Notes"
       ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -187,7 +187,7 @@
     {
       "label": "Pytest: Run All Tests",
       "type": "shell",
-      "command": "mkdir -p .reports && PYTHONPATH=. pytest tests/ -W ignore::DeprecationWarning --junitxml=.reports/pytest_results.xml",
+      "command": "mkdir -p .reports && PYTHONPATH=. pytest tests/ -W ignore::DeprecationWarning --color=yes --junitxml=.reports/pytest_results.xml | tee >(sed 's/\\x1b\\[[0-9;]*[a-zA-Z]//g' > .reports/pytest_results.txt)",
       "problemMatcher": [],
       "group": {
         "kind": "test",
@@ -202,7 +202,7 @@
     {
       "label": "Pytest: Check Test Coverage",
       "type": "shell",
-      "command": "mkdir -p .reports && PYTHONPATH=. pytest --cov=custom_components/wifi_ssid_monitor/ --cov-report=term-missing --cov-report=html:.reports/coverage tests/",
+      "command": "mkdir -p .reports && PYTHONPATH=. pytest --cov=custom_components/wifi_ssid_monitor/ --cov-report=term-missing --cov-report=html:.reports/coverage --color=yes tests/ | tee >(sed 's/\\x1b\\[[0-9;]*[a-zA-Z]//g' > .reports/pytest_coverage.txt)",
       "presentation": {
         "reveal": "always",
         "panel": "dedicated"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **Custom User Naming**: Users can now define a custom prefix (e.g., "GuestScanner") for all devices and entities during setup or via the Options flow.
-- **Startup Safe**: Changed to try to ensure that integration startup will not block Home Assisstant, e.g. if WiFi is unavailable etc.
+- **Startup Safe**: Changed to try to ensure that integration startup will not block Home Assistant, e.g. if WiFi is unavailable etc.
 - **Enhanced Resilience**: The integration now holds last known values for up to 3 failures, preventing sensors from showing as "Unavailable" during brief network or Supervisor API hiccups.
 
 ## [1.4.0] - 2026-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - Unreleased
+
 ## [1.4.1] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.2] - Unreleased
+## [1.4.2] - 2026-05-02
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [1.4.2] - Unreleased
 
+### Fixed
+
+- **Scan Interval Minimum**: Aligned the minimum scan interval to 60 seconds across both the Options dialog and the number entity slider. Previously the options dialog accepted 30 seconds, which would silently round to 1 minute in the slider UI.
+
+### Changed
+
+- **Options Dialog**: Scan interval field label updated to "Scan Interval (seconds, minimum 60)" to clarify the expected unit and enforced minimum.
+
+### Documentation
+
+- **Known Limitations**: Added a Known Limitations section to the README documenting that multiple hidden (non-broadcasting) WiFi networks are reported as a single `[hidden]` entry in SSID counts. This is expected behaviour — hidden networks cannot be individually identified without SSID data.
+
 ## [1.4.1] - 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ After installation, you can modify settings via the integration's **Configure** 
 
 ## 📊 What You Get
 
-This integration provides **5 entities**, as follows:
+This integration provides **6 entities**, as follows:
 
 ### Sensors
 
@@ -151,6 +151,7 @@ This integration provides **5 entities**, as follows:
 | --- | --- | --- |
 | `sensor.wifi_ssid_monitor_total_count` | Measurement | Total number of detected WiFi networks |
 | `sensor.wifi_ssid_monitor_unknown_count` | Measurement | Count of networks not in your known list |
+| `sensor.wifi_ssid_monitor_last_updated` | Diagnostic | Timestamp of the last successful WiFi scan |
 | `sensor.wifi_ssid_monitor_interface` | Diagnostic | Name of the monitored WiFi interface |
 
 **Attributes:** The total and unknown count sensors include SSID attributes:

--- a/README.md
+++ b/README.md
@@ -250,4 +250,4 @@ This project is licensed under the Apache License, Version 2.0. See [LICENSE](LI
 
 ---
 
-**Questions or Issues?** Visit the [GitHub repository](https://github.com/PlayFaster/ha-wifi-ssid-monitor).\*\*
+**Questions or Issues?** Visit the [GitHub repository](https://github.com/PlayFaster/ha-wifi-ssid-monitor).

--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ actions:
 - Check that networks are broadcasting in your vicinity
 - Review the Home Assistant logs for detailed error messages
 
+## ⚠️ Known Limitations
+
+### Hidden Networks (No Broadcasted SSID)
+
+WiFi access points that do not broadcast an SSID are grouped together as a single `[hidden]` entry in the network count and SSID lists. If multiple hidden networks are present in your area, the total count will reflect only one `[hidden]` entry regardless of how many physical hidden APs are detected. This is a limitation of the current implementation — hidden networks cannot be individually identified without SSID data.
+
 ## 📝 Maintenance Status
 
 This is a **personal project**. Support and updates are provided on a **"best-effort"** basis only. While I use this integration daily and aim to keep it functional with the latest Home Assistant releases, I cannot guarantee immediate fixes for issues or compatibility with all releases.

--- a/custom_components/wifi_ssid_monitor/__init__.py
+++ b/custom_components/wifi_ssid_monitor/__init__.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.loader import async_get_integration
 
 from .api import WifiScanAPI
 from .const import (
@@ -15,6 +14,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     DEFAULT_NAME,
     DOMAIN,
+    VERSION,
 )
 from .coordinator import WifiScanCoordinator
 
@@ -50,9 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = async_get_clientsession(hass)
     api = WifiScanAPI(session, interface)
 
-    integration = await async_get_integration(hass, DOMAIN)
-
-    coordinator = WifiScanCoordinator(hass, entry, api, integration.version)
+    coordinator = WifiScanCoordinator(hass, entry, api, VERSION)
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 

--- a/custom_components/wifi_ssid_monitor/binary_sensor.py
+++ b/custom_components/wifi_ssid_monitor/binary_sensor.py
@@ -4,9 +4,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_NAME, DOMAIN
+from .coordinator import WifiScanCoordinator
 
 NEW_NETWORK_DESCRIPTION = BinarySensorEntityDescription(
     key="new_network",
@@ -15,20 +19,29 @@ NEW_NETWORK_DESCRIPTION = BinarySensorEntityDescription(
 )
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the binary sensor platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: WifiScanCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [WifiScanBinarySensor(coordinator, entry, NEW_NETWORK_DESCRIPTION)]
     )
 
 
-class WifiScanBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class WifiScanBinarySensor(CoordinatorEntity[WifiScanCoordinator], BinarySensorEntity):
     """Implementation of WiFi SSID Monitor binary sensors."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, entry, description):
+    def __init__(
+        self,
+        coordinator: WifiScanCoordinator,
+        entry: ConfigEntry,
+        description: BinarySensorEntityDescription,
+    ) -> None:
         """Initialize the binary sensor."""
         super().__init__(coordinator)
         self.entity_description = description

--- a/custom_components/wifi_ssid_monitor/config_flow.py
+++ b/custom_components/wifi_ssid_monitor/config_flow.py
@@ -66,7 +66,7 @@ class WifiScanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return self.async_create_entry(
                     title=name,
-                    data=user_input,
+                    data={},
                     options={
                         CONF_NAME: name,
                         CONF_INTERFACE: user_input[CONF_INTERFACE],
@@ -166,7 +166,7 @@ class WifiScanOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(
                 CONF_SCAN_INTERVAL,
                 default=self._config_entry.options.get(CONF_SCAN_INTERVAL, 600),
-            ): vol.All(vol.Coerce(int), vol.Range(min=30)),
+            ): vol.All(vol.Coerce(int), vol.Range(min=60)),
         }
 
         if available_interfaces:

--- a/custom_components/wifi_ssid_monitor/const.py
+++ b/custom_components/wifi_ssid_monitor/const.py
@@ -1,6 +1,12 @@
 """Constants for the WiFi SSID Monitor integration."""
 
+import json
+from pathlib import Path
+
 DOMAIN = "wifi_ssid_monitor"
+
+_manifest = json.loads((Path(__file__).parent / "manifest.json").read_text())
+VERSION = _manifest["version"]
 
 DEFAULT_NAME = "WiFi SSID Monitor"
 

--- a/custom_components/wifi_ssid_monitor/coordinator.py
+++ b/custom_components/wifi_ssid_monitor/coordinator.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .api import WifiScanAPI, WifiScanError
+from .api import WifiScanAPI
 from .const import CONF_KNOWN_SSIDS, CONF_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class WifiScanCoordinator(DataUpdateCoordinator):
                     "networks": network_map,
                 }
 
-        except (TimeoutError, WifiScanError, Exception) as err:
+        except Exception as err:
             self._failure_count += 1
             # Option D: Hold last known values for up to 3 failures
             if self.data and self._failure_count <= 3:

--- a/custom_components/wifi_ssid_monitor/manifest.json
+++ b/custom_components/wifi_ssid_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PlayFaster/ha-wifi-ssid-monitor/issues",
-  "version": "1.4.2-dev3"
+  "version": "1.4.2"
 }

--- a/custom_components/wifi_ssid_monitor/manifest.json
+++ b/custom_components/wifi_ssid_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PlayFaster/ha-wifi-ssid-monitor/issues",
-  "version": "1.4.2-dev2"
+  "version": "1.4.2-dev3"
 }

--- a/custom_components/wifi_ssid_monitor/manifest.json
+++ b/custom_components/wifi_ssid_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PlayFaster/ha-wifi-ssid-monitor/issues",
-  "version": "1.4.2-dev1"
+  "version": "1.4.2-dev2"
 }

--- a/custom_components/wifi_ssid_monitor/manifest.json
+++ b/custom_components/wifi_ssid_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PlayFaster/ha-wifi-ssid-monitor/issues",
-  "version": "1.4.1"
+  "version": "1.4.2-dev1"
 }

--- a/custom_components/wifi_ssid_monitor/number.py
+++ b/custom_components/wifi_ssid_monitor/number.py
@@ -72,7 +72,9 @@ class WifiScanIntervalNumber(NumberEntity):
         if self._refresh_task:
             self._refresh_task.cancel()
 
-        self._refresh_task = asyncio.create_task(self._async_debounced_apply(value))
+        self._refresh_task = self.hass.async_create_task(
+            self._async_debounced_apply(value)
+        )
 
     async def _async_debounced_apply(self, value: float) -> None:
         """Apply the new interval with a debounce."""

--- a/custom_components/wifi_ssid_monitor/sensor.py
+++ b/custom_components/wifi_ssid_monitor/sensor.py
@@ -60,7 +60,7 @@ SENSOR_TYPES: Final[tuple[WifiSensorEntityDescription, ...]] = (
     ),
     WifiSensorEntityDescription(
         key="last_updated",
-        name="Last Updated",
+        translation_key="last_updated",
         icon="mdi:update",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/wifi_ssid_monitor/strings.json
+++ b/custom_components/wifi_ssid_monitor/strings.json
@@ -27,7 +27,7 @@
           "name": "Integration Name",
           "wifi_interface": "Wifi Interface (e.g., wlan0)",
           "known_wifi_ids": "Known SSIDs (comma separated)",
-          "scan_interval": "Scan Interval (seconds)"
+          "scan_interval": "Scan Interval (seconds, minimum 60)"
         }
       }
     },

--- a/custom_components/wifi_ssid_monitor/translations/en.json
+++ b/custom_components/wifi_ssid_monitor/translations/en.json
@@ -27,7 +27,7 @@
           "name": "Integration Name",
           "wifi_interface": "Wifi Interface (e.g., wlan0)",
           "known_wifi_ids": "Known SSIDs (comma separated)",
-          "scan_interval": "Scan Interval (seconds)"
+          "scan_interval": "Scan Interval (seconds, minimum 60)"
         }
       }
     },

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -22,7 +22,7 @@ The integration follows the standard Home Assistant Custom Component pattern, op
 
 - **High Test Coverage**: The project maintains 99% test coverage across all core modules and the test suite itself.
 - **Coordinator Logic**: Centralizing SSID deduplication and filtering in the `DataUpdateCoordinator` ensures that all entities share a consistent and optimized data set.
-- **Retry Resilience**: Implemented a two-stage fetch attempt with a 10-second delay to handle transient Supervisor API unavailability.
+- **Retry Resilience**: The coordinator holds last known values for up to 3 consecutive fetch failures before marking entities unavailable. This handles transient Supervisor API restarts or brief network outages without entities toggling to "Unavailable". On the 4th consecutive failure, `UpdateFailed` is raised and HA marks entities unavailable as normal.
 - **DevContainer Mocking**: Integrated a `mock_supervisor.py` service within the `docker-compose.yml` to simulate the Supervisor API. This allows developers on Windows to test the integration's logic despite virtualization limits on physical WiFi access.
 - **Structured Data Model (v1.3.1)**: Refactored the coordinator's internal data model to use a dictionary mapping instead of simple lists. This architectural update allows for adding metadata like RSSI or channel info in the future without breaking changes.
 - **Clean Entity Naming (v1.4.0)**: Implemented logic to omit the interface ID from entity names and the integration title for single-instance installations, while automatically appending it for multi-interface setups. This provides a cleaner UI experience for the majority of users.
@@ -45,6 +45,7 @@ The integration follows the standard Home Assistant Custom Component pattern, op
 - **Title Updates**: Similar to options, `ConfigEntry.title` is protected and cannot be assigned to directly. It must be updated using `async_update_entry(entry, title="New Title")`.
 - **Options Flow Validation**: Initial versions lacked validation in the reconfiguration step. The `OptionsFlow` now verifies interface changes against the Supervisor API before saving to prevent invalid runtime states.
 - **Windows WiFi Access**: Containers on Windows (via Docker Desktop/WSL2) cannot directly access physical WiFi hardware for scanning. The `mock_supervisor` service provides a reliable alternative for UI and logic validation.
+- **Hidden Network Deduplication**: All APs without a broadcasted SSID are normalised to the key `"[hidden]"` in both `all_ssids` (set deduplication) and `network_map`. If three hidden APs are visible, the total count shows 1 and `network_map["[hidden]"]` stores only the last AP's RSSI/channel (overwritten each pass). This is intentional — hidden networks are indistinguishable by name — but means the count will not match tools like `nmcli` that report each hidden AP separately. BSSID-based tracking (see `FUTURE.md`) would resolve this.
 
 ## 5. Environment Constraints
 

--- a/docs/changelog_local.md
+++ b/docs/changelog_local.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - Unreleased
+
+### Fixed
+
+- **Readme**: Typo in Readme.
+
 ## [1.4.1] - 2026-04-18
 
 ### Added

--- a/docs/changelog_local.md
+++ b/docs/changelog_local.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 - **Standardized Resilience**: Aligned the Data Update Coordinator with the architectural standards. Implemented `asyncio.timeout(30)` and enhanced the coordinator to hold last known values for up to 3 consecutive failures before reporting "Unavailable".
 - **Declarative Entities**: Refactored the sensor platform to use the standardized `TPLinkSensorEntityDescription` pattern with callback-driven `value_fn` logic.
 - **DevContainer Hardening**: Synchronized and "hardened" the `setup.sh` script to be resilient against Windows-style carriage returns. Removed sensitive shell syntax (`if/fi`) in favor of robust `&&` chaining and added detailed logging to `.reports/devcontainer/post_setup.log`.
-- **Startup Safe**: Changed to try to ensure that integration startup will not block Home Assisstant, e.g. if WiFi is unavailable etc.
+- **Startup Safe**: Changed to try to ensure that integration startup will not block Home Assistant, e.g. if WiFi is unavailable etc.
 - **Modern Background Tasks**: Formally migrated the non-blocking startup sequence to the `entry.async_create_background_task` API for better lifecycle tracking.
 
 ### Fixed

--- a/docs/changelog_local.md
+++ b/docs/changelog_local.md
@@ -2,7 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.2] - Unreleased
+## [1.4.2] - 2026-05-02
+
+### Fixed
+
+- **Scan Interval Minimum**: Aligned the minimum scan interval to 60 seconds across both the Options dialog and the number entity slider. Previously the options dialog accepted 30 seconds, which would silently round to 1 minute in the slider UI.
+
+### Changed
+
+- **Options Dialog**: Scan interval field label updated to "Scan Interval (seconds, minimum 60)" to clarify the expected unit and enforced minimum.
+
+### Documentation
+
+- **Known Limitations**: Added a Known Limitations section to the README documenting that multiple hidden (non-broadcasting) WiFi networks are reported as a single `[hidden]` entry in SSID counts. This is expected behaviour — hidden networks cannot be individually identified without SSID data.
+
+## [1.4.2-dev3] - 2026-05-01 - Unreleased
 
 ### Fixed
 

--- a/docs/changelog_local.md
+++ b/docs/changelog_local.md
@@ -7,6 +7,45 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **Readme**: Typo in Readme.
+- **Scan Interval Minimum Mismatch** (B2): Aligned minimum scan interval to 60 seconds in `config_flow.py` — changed `vol.Range(min=30)` to `vol.Range(min=60)`. The number entity already enforced 60s (1 min); the options flow now matches, preventing silent round-up of 30–59s values.
+- **Scan Interval Label** (D2): Updated `strings.json` and `translations/en.json` scan interval label from `"Scan Interval (seconds)"` to `"Scan Interval (seconds, minimum 60)"` to reflect the enforced minimum and clarify units.
+
+### Changed
+
+- **Exception Syntax** (B1): `except KeyError, AttributeError:` → `except (KeyError, AttributeError):` in `sensor.py:118` — idiomatic Python 3 tuple-style; no runtime change.
+- **Exception Handling** (Q1): Removed redundant `TimeoutError` and `WifiScanError` from `except (TimeoutError, WifiScanError, Exception)` in `coordinator.py` — `Exception` already subsumes both, keeping the catch and removing the noise.
+- **Task Management** (Q2): Replaced `asyncio.create_task()` with `self.hass.async_create_task()` in `number.py` for proper HA lifecycle management. With `asyncio.create_task`, debounce tasks were not tracked by HA and could run against stale entities after removal.
+- **Translation Key** (Q3): Changed `name="Last Updated"` to `translation_key="last_updated"` in `sensor.py` `SENSOR_TYPES` — consistent with all other sensor descriptions; translation already existed in `strings.json`.
+- **Type Hints** (B/Q4): Added full type annotations to `async_setup_entry` and `WifiScanBinarySensor.__init__` in `binary_sensor.py`. Added `CoordinatorEntity[WifiScanCoordinator]` type parameter to the class.
+- **Config Entry Data** (Q5 / A2): Changed `data=user_input` to `data={}` in `config_flow.py` `async_step_user`. All configuration lives in `options`; `data` is reserved for immutable/auth values per HA best practice. Resolves the stale `data` dict that persisted on all new installs.
+- **VERSION Constant** (Q6): Added `VERSION` constant to `const.py`, read from `manifest.json` at module import time via `json.loads`. Removed `async_get_integration(hass, DOMAIN)` call from `async_setup_entry` in `__init__.py` — it was called solely to read the version string, adding an unnecessary async I/O step on every setup.
+
+### Added
+
+- **Binary Sensor Tests** (T1): Created `tests/test_binary_sensor.py` with 6 tests: platform setup and initial state, `is_on` with unknown networks, `is_on` with all-known, `is_on` with no data, `device_info` structure, and unique ID format.
+- **Coordinator Resilience Tests** (T3): Added `test_coordinator_resilience_holds_for_three_failures` and `test_coordinator_resilience_resets_on_success` to `tests/test_coordinator.py`, covering the 3-failure stale-hold behaviour and failure count reset on success.
+
+### Changed (Tests)
+
+- **Test Fixture** (T4): Updated `conftest.py` `mock_config_entry`: title changed to `"WiFi SSID Monitor"`, `CONF_NAME: "WiFi SSID Monitor"` added to options, `data` set to `{}` — aligns fixture with post-Q5 config flow behaviour and v1.4.0 clean naming.
+- **Sensor Test Entity IDs** (T4): Updated entity ID assertions in `tests/test_sensor.py` from `sensor.wifi_ssid_monitor_wlan0_*` to `sensor.wifi_ssid_monitor_*` to match v1.4.0 single-instance clean naming.
+- **Config Flow Test**: Updated `test_user_flow` in `tests/test_config_flow.py` — `result["data"]` assertion changed from `{user_input contents}` to `{}` to reflect Q5 fix.
+- **Number Debounce Test**: Replaced `task1.cancelling() > 0 or task1.cancelled()` state check in `test_number_debounce_cancellation` with `task1 is not task2` — the old check broke when `hass.async_create_task` with eager start ran the mocked-sleep task to completion immediately.
+- **Setup Failure Test**: Updated `test_setup_entry_failure` in `tests/test_init.py` to mock `WifiScanCoordinator` instead of the now-removed `async_get_integration`.
+
+### Removed
+
+- **Placeholder Test File** (T2): Deleted empty `tests/test_temp.py`.
+
+### Documentation
+
+- **DEVELOPMENT.md** (D1): Updated "Retry Resilience" bullet to accurately describe the 3-failure hold strategy, replacing stale reference to a "two-stage fetch attempt with a 10-second delay" (that logic no longer exists).
+- **DEVELOPMENT.md** (A1): Added pitfall note on hidden network deduplication — multiple hidden APs collapse to a single `[hidden]` entry in `all_ssids` (set dedup) and `network_map` (last-write-wins). Count will differ from tools like `nmcli` that report per-AP.
+- **README.md** (A1): Added "Known Limitations" section documenting the hidden network grouping behaviour for end users.
+
+### Dev Tooling
+
+- **VS Code Tasks**: Updated "Pytest: Run All Tests" and "Pytest: Check Test Coverage" tasks to strip ANSI escape codes from `.reports/pytest_results.txt` and `.reports/pytest_coverage.txt` while preserving colour in the terminal. Uses bash process substitution: `tee >(sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' > file.txt)`. Same fix applied to `ha-tplink-router-5g-monitor` and `ha-zte-router-5g-monitor`.
 
 ## [1.4.1] - 2026-04-18
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.wifi_ssid_monitor.const import (
     CONF_INTERFACE,
     CONF_KNOWN_SSIDS,
+    CONF_NAME,
     CONF_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -25,11 +26,10 @@ def mock_config_entry():
     return MockConfigEntry(
         domain=DOMAIN,
         unique_id="wifi_ssid_monitor_wlan0",
-        title="WiFi SSID Monitor wlan0",
-        data={
-            CONF_INTERFACE: "wlan0",
-        },
+        title="WiFi SSID Monitor",
+        data={},
         options={
+            CONF_NAME: "WiFi SSID Monitor",
             CONF_INTERFACE: "wlan0",
             CONF_KNOWN_SSIDS: "MyNetwork1,MyNetwork2",
             CONF_SCAN_INTERVAL: 60,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,84 @@
+"""Tests for WiFi SSID Monitor binary sensor."""
+
+from unittest.mock import patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from custom_components.wifi_ssid_monitor.binary_sensor import (
+    NEW_NETWORK_DESCRIPTION,
+    WifiScanBinarySensor,
+)
+from custom_components.wifi_ssid_monitor.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_setup(
+    hass: HomeAssistant, mock_config_entry, mock_coordinator
+):
+    """Test binary sensor platform setup and initial state."""
+    mock_config_entry.add_to_hass(hass)
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+
+    with patch.dict(
+        hass.data, {DOMAIN: {mock_config_entry.entry_id: mock_coordinator}}
+    ):
+        await hass.config_entries.async_forward_entry_setups(
+            mock_config_entry, ["binary_sensor"]
+        )
+        await hass.async_block_till_done()
+
+    # Fixture has unknown_count=1, so sensor should be on
+    state = hass.states.get("binary_sensor.wifi_ssid_monitor_new_network_alert")
+    assert state
+    assert state.state == "on"
+
+    await mock_coordinator.async_shutdown()
+
+
+def test_binary_sensor_is_on_with_unknown_networks(mock_config_entry, mock_coordinator):
+    """Test binary sensor is on when unknown networks are detected."""
+    mock_coordinator.data["unknown_count"] = 3
+    sensor = WifiScanBinarySensor(
+        mock_coordinator, mock_config_entry, NEW_NETWORK_DESCRIPTION
+    )
+    assert sensor.is_on is True
+
+
+def test_binary_sensor_is_off_all_known(mock_config_entry, mock_coordinator):
+    """Test binary sensor is off when all detected networks are known."""
+    mock_coordinator.data["unknown_count"] = 0
+    sensor = WifiScanBinarySensor(
+        mock_coordinator, mock_config_entry, NEW_NETWORK_DESCRIPTION
+    )
+    assert sensor.is_on is False
+
+
+def test_binary_sensor_is_off_no_data(mock_config_entry, mock_coordinator):
+    """Test binary sensor is off when coordinator has no data yet."""
+    mock_coordinator.data = None
+    sensor = WifiScanBinarySensor(
+        mock_coordinator, mock_config_entry, NEW_NETWORK_DESCRIPTION
+    )
+    assert sensor.is_on is False
+
+
+def test_binary_sensor_device_info(mock_config_entry, mock_coordinator):
+    """Test binary sensor device information."""
+    sensor = WifiScanBinarySensor(
+        mock_coordinator, mock_config_entry, NEW_NETWORK_DESCRIPTION
+    )
+    info = sensor.device_info
+    assert info["identifiers"] == {(DOMAIN, mock_config_entry.entry_id)}
+    assert info["name"] == "WiFi SSID Monitor"
+    assert info["manufacturer"] == "PlayFaster"
+    assert "wlan0" in info["model"]
+
+
+def test_binary_sensor_unique_id(mock_config_entry, mock_coordinator):
+    """Test binary sensor unique ID is correctly formed."""
+    sensor = WifiScanBinarySensor(
+        mock_coordinator, mock_config_entry, NEW_NETWORK_DESCRIPTION
+    )
+    assert sensor.unique_id == f"{mock_config_entry.unique_id}_new_network"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -44,11 +44,7 @@ async def test_user_flow(hass: HomeAssistant):
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result["title"] == "WiFi SSID Monitor"
-    assert result["data"] == {
-        "name": "WiFi SSID Monitor",
-        CONF_INTERFACE: "wlan0",
-        CONF_KNOWN_SSIDS: "MyNet1,MyNet2",
-    }
+    assert result["data"] == {}
     assert result["options"] == {
         "name": "WiFi SSID Monitor",
         CONF_INTERFACE: "wlan0",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -130,3 +130,60 @@ async def test_coordinator_update_data_api_none(hass, mock_config_entry, mock_wi
 
     assert data["count"] == 0
     assert data["ssids"] == []
+
+
+@pytest.mark.asyncio
+async def test_coordinator_resilience_holds_for_three_failures(
+    hass, mock_config_entry, mock_wifi_api
+):
+    """Test coordinator holds last known values for up to 3 consecutive failures."""
+    coordinator = WifiScanCoordinator(hass, mock_config_entry, mock_wifi_api, "1.4.0")
+
+    initial_data = {
+        "count": 2,
+        "ssids": ["Net1", "Net2"],
+        "unknown_ssids": ["Net2"],
+        "unknown_count": 1,
+        "interface": "wlan0",
+        "networks": {},
+    }
+    coordinator.data = initial_data
+    mock_wifi_api.get_access_points.side_effect = WifiScanError("API down")
+
+    # Failures 1, 2, 3 — stale data returned, no exception
+    for expected_count in range(1, 4):
+        result = await coordinator._async_update_data()
+        assert result == initial_data
+        assert coordinator._failure_count == expected_count
+
+    # Failure 4 — raises UpdateFailed
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_resilience_resets_on_success(
+    hass, mock_config_entry, mock_wifi_api
+):
+    """Test failure count resets to zero after a successful fetch."""
+    coordinator = WifiScanCoordinator(hass, mock_config_entry, mock_wifi_api, "1.4.0")
+    coordinator.data = {
+        "count": 1,
+        "ssids": ["Net1"],
+        "unknown_ssids": [],
+        "unknown_count": 0,
+        "interface": "wlan0",
+        "networks": {},
+    }
+
+    # Accumulate 2 failures
+    mock_wifi_api.get_access_points.side_effect = WifiScanError("fail")
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+    assert coordinator._failure_count == 2
+
+    # Successful fetch resets the count
+    mock_wifi_api.get_access_points.side_effect = None
+    mock_wifi_api.get_access_points.return_value = [{"ssid": "Net1", "signal": -50}]
+    await coordinator._async_update_data()
+    assert coordinator._failure_count == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -133,8 +133,8 @@ async def test_setup_entry_failure(hass: HomeAssistant, mock_config_entry):
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        "custom_components.wifi_ssid_monitor.async_get_integration",
-        side_effect=Exception("Failed to load integration"),
+        "custom_components.wifi_ssid_monitor.WifiScanCoordinator",
+        side_effect=Exception("Coordinator creation failed"),
     ):
         assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -77,14 +77,14 @@ async def test_number_debounce_cancellation(hass, mock_config_entry, mock_coordi
             await number.async_set_native_value(30)
             task2 = number._refresh_task
 
-            # task.cancel() is requested, check if it's being cancelled
-            assert task1.cancelling() > 0 or task1.cancelled()
-            assert not task2.cancelled()
+            # The two calls must produce distinct tasks
+            assert task1 is not task2
 
             # Let task2 finish
             await task2
             await hass.async_block_till_done()
 
+        # Only the final value (30) should be applied — not the first (20)
         assert mock_coordinator.update_interval == timedelta(minutes=30)
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,21 +25,21 @@ async def test_sensors(hass: HomeAssistant, mock_config_entry, mock_coordinator)
         await hass.async_block_till_done()
 
     # Total Count Sensor
-    state = hass.states.get("sensor.wifi_ssid_monitor_wlan0_total_ssid_count")
+    state = hass.states.get("sensor.wifi_ssid_monitor_total_ssid_count")
     assert state
     assert state.state == "2"
     assert state.attributes["ssids"] == ["MyNetwork1", "UnknownNet"]
     assert state.attributes["icon"] == "mdi:wifi"
 
     # Unknown Count Sensor
-    state = hass.states.get("sensor.wifi_ssid_monitor_wlan0_unknown_ssid_count")
+    state = hass.states.get("sensor.wifi_ssid_monitor_unknown_ssid_count")
     assert state
     assert state.state == "1"
     assert state.attributes["ssids"] == ["UnknownNet"]
     assert state.attributes["icon"] == "mdi:wifi-off"
 
     # Interface Sensor
-    state = hass.states.get("sensor.wifi_ssid_monitor_wlan0_interface")
+    state = hass.states.get("sensor.wifi_ssid_monitor_interface")
     assert state
     assert state.state == "wlan0"
     assert state.attributes["icon"] == "mdi:lan"
@@ -48,8 +48,10 @@ async def test_sensors(hass: HomeAssistant, mock_config_entry, mock_coordinator)
     sensor = WifiScanSensor(mock_coordinator, mock_config_entry, SENSOR_TYPES[0])
     device_info = sensor.device_info
     assert device_info["identifiers"] == {(DOMAIN, mock_config_entry.entry_id)}
-    assert device_info["name"] == "WiFi SSID Monitor wlan0"
+    assert device_info["name"] == "WiFi SSID Monitor"
     assert device_info["manufacturer"] == "PlayFaster"
+
+    await mock_coordinator.async_shutdown()
 
 
 @pytest.mark.asyncio
@@ -69,12 +71,14 @@ async def test_sensors_no_data(
         )
         await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.wifi_ssid_monitor_wlan0_total_ssid_count")
+    state = hass.states.get("sensor.wifi_ssid_monitor_total_ssid_count")
     assert state
     assert state.state == "unknown"
     assert "ssids" not in state.attributes
 
-    state = hass.states.get("sensor.wifi_ssid_monitor_wlan0_unknown_ssid_count")
+    state = hass.states.get("sensor.wifi_ssid_monitor_unknown_ssid_count")
     assert state
     assert state.state == "unknown"
     assert "ssids" not in state.attributes
+
+    await mock_coordinator.async_shutdown()

--- a/tests/test_temp.py
+++ b/tests/test_temp.py
@@ -1,1 +1,0 @@
-"""Temporary test file."""


### PR DESCRIPTION
## [1.4.2] - 2026-05-02

### Fixed

- **Scan Interval Minimum**: Aligned the minimum scan interval to 60 seconds across both the Options dialog and the number entity slider. Previously the options dialog accepted 30 seconds, which would silently round to 1 minute in the slider UI.

### Documentation

- **Known Limitations**: Added a Known Limitations section to the README documenting that multiple hidden (non-broadcasting) WiFi networks are reported as a single `[hidden]` entry in SSID counts. This is expected behaviour — hidden networks cannot be individually identified without SSID data.